### PR TITLE
Fix reference genome optionality

### DIFF
--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -1,4 +1,4 @@
-<tool id="jbrowse2" name="JBrowse2" version="@TOOL_VERSION@+@WRAPPER_VERSION@_17" profile="22.05">
+<tool id="jbrowse2" name="JBrowse2" version="@TOOL_VERSION@+@WRAPPER_VERSION@_18" profile="22.05">
     <description>genome browser</description>
     <macros>
         <import>macros.xml</import>
@@ -329,7 +329,7 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
                         tabix bgzip with predictable index file URI</option>
                 </param>
                 <when value="indexed">
-                    <param name="genome" type="select" optional="true" label="Select a built in reference genome or custom genome" help="If not listed, add a custom genome, use a history genome or a remote URI tabix genome">
+                    <param name="genome" type="select" label="Select a built in reference genome or custom genome" help="If not listed, add a custom genome, use a history genome or a remote URI tabix genome">
                         <options from_data_table="all_fasta">
                             <filter column="2" type="sort_by"/>
                             <validator message="No genomes are available for the selected input dataset" type="no_options">
@@ -338,7 +338,7 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
                     </param>
                 </when>
                 <when value="history">
-                    <param name="genome" type="data" format="fasta" optional="true" label="Select the reference genome">
+                    <param name="genome" type="data" format="fasta" label="Select the reference genome">
                     </param>
                 </when>
                 <when value="uri">


### PR DESCRIPTION
You can of course add a fourth option to not select a genome in `genome_type_select` if that should be an option, but the way you've built the config file you can't have optional reference genome parameters, this would fail as in https://sentry.galaxyproject.org/share/issue/08f9946cf5f24d7591fec0b40203e38b/

```
ValueError: Data must be aligned to block boundary in ECB mode
  File "galaxy/tools/evaluation.py", line 107, in global_tool_logs
    return func()
  File "galaxy/tools/evaluation.py", line 681, in _build_config_files
    self.__write_workdir_file(config_filename, config_text, param_dict, is_template=is_template)
  File "galaxy/tools/evaluation.py", line 814, in __write_workdir_file
    value = fill_template(content, context=context, python_template_version=self.tool.python_template_version)
  File "galaxy/util/template.py", line 143, in fill_template
    raise first_exception or e
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1723993334_7252746_87567.py", line 188, in respond
  File "galaxy/security/idencoding.py", line 49, in encode_id
    return unicodify(codecs.encode(id_cipher.encrypt(s), "hex"))
  File "Crypto/Cipher/_mode_ecb.py", line 141, in encrypt
    raise ValueError("Data must be aligned to block boundary in ECB mode")
ToolTemplatingException: Error occurred while building config files for tool 'toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/2.13.0+galaxy0'
  File "galaxy/jobs/runners/__init__.py", line 297, in prepare_job
    job_wrapper.prepare()
  File "galaxy/jobs/__init__.py", line 1260, in prepare
    ) = tool_evaluator.build()
  File "galaxy/tools/evaluation.py", line 604, in build
    global_tool_logs(
  File "galaxy/tools/evaluation.py", line 111, in global_tool_logs
    raise ToolTemplatingException(
```

which happens when no reference genome is provided from your history, so `${__app__.security.encode_id($assembly.reference_genome.genome.id)}` becomes `__app__.security.encode_id(None)`, which is not valid.